### PR TITLE
fix: sort lists case-insensitively

### DIFF
--- a/repository/src/main/java/app/simple/felicity/repository/sort/AlbumArtistSort.kt
+++ b/repository/src/main/java/app/simple/felicity/repository/sort/AlbumArtistSort.kt
@@ -22,8 +22,8 @@ object AlbumArtistSort {
     fun List<Artist>.sortedAlbumArtists(): List<Artist> {
         return when (AlbumArtistPreferences.getAlbumArtistSort()) {
             CommonPreferencesConstants.BY_NAME -> when (AlbumArtistPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.name }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.name }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.name?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.name?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_NUMBER_OF_ALBUMS -> when (AlbumArtistPreferences.getSortingStyle()) {

--- a/repository/src/main/java/app/simple/felicity/repository/sort/AlbumSort.kt
+++ b/repository/src/main/java/app/simple/felicity/repository/sort/AlbumSort.kt
@@ -11,13 +11,13 @@ object AlbumSort {
     fun List<Album>.sorted(): List<Album> {
         return when (AlbumPreferences.getAlbumSort()) {
             CommonPreferencesConstants.BY_ALBUM_NAME -> when (AlbumPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.name }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.name }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.name?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.name?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_ARTIST -> when (AlbumPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.artist }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.artist }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.artist?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.artist?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_NUMBER_OF_SONGS -> when (AlbumPreferences.getSortingStyle()) {

--- a/repository/src/main/java/app/simple/felicity/repository/sort/ArtistSort.kt
+++ b/repository/src/main/java/app/simple/felicity/repository/sort/ArtistSort.kt
@@ -11,8 +11,8 @@ object ArtistSort {
     fun List<Artist>.sorted(): List<Artist> {
         return when (ArtistPreferences.getArtistSort()) {
             CommonPreferencesConstants.BY_NAME -> when (ArtistPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.name }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.name }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.name?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.name?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_NUMBER_OF_ALBUMS -> when (ArtistPreferences.getSortingStyle()) {

--- a/repository/src/main/java/app/simple/felicity/repository/sort/ComposerSort.kt
+++ b/repository/src/main/java/app/simple/felicity/repository/sort/ComposerSort.kt
@@ -11,8 +11,8 @@ object ComposerSort {
     fun List<Artist>.sortedComposers(): List<Artist> {
         return when (ComposerPreferences.getComposerSort()) {
             CommonPreferencesConstants.BY_NAME -> when (ComposerPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.name }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.name }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.name?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.name?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_NUMBER_OF_SONGS -> when (ComposerPreferences.getSortingStyle()) {

--- a/repository/src/main/java/app/simple/felicity/repository/sort/FavoritesSort.kt
+++ b/repository/src/main/java/app/simple/felicity/repository/sort/FavoritesSort.kt
@@ -21,23 +21,23 @@ object FavoritesSort {
     fun List<Audio>.sortedFavorites(): List<Audio> {
         return when (FavoritesPreferences.getSongSort()) {
             CommonPreferencesConstants.BY_TITLE -> when (FavoritesPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.title }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.title }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.title?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.title?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_ARTIST -> when (FavoritesPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.artist }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.artist }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.artist?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.artist?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_ALBUM -> when (FavoritesPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.album }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.album }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.album?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.album?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_PATH -> when (FavoritesPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.uri }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.uri }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.uri?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.uri?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_DATE_ADDED -> when (FavoritesPreferences.getSortingStyle()) {
@@ -66,8 +66,8 @@ object FavoritesSort {
                 else -> this
             }
             CommonPreferencesConstants.BY_COMPOSER -> when (FavoritesPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.composer }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.composer }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.composer?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.composer?.lowercase() }
                 else -> this
             }
             else -> this

--- a/repository/src/main/java/app/simple/felicity/repository/sort/PageSort.kt
+++ b/repository/src/main/java/app/simple/felicity/repository/sort/PageSort.kt
@@ -63,10 +63,10 @@ object PageSort {
     private fun List<Audio>.applySort(sortField: Int, order: Int): List<Audio> {
         val ascending = order == CommonPreferencesConstants.ASCENDING
         return when (sortField) {
-            CommonPreferencesConstants.BY_TITLE -> if (ascending) sortedBy { it.title } else sortedByDescending { it.title }
-            CommonPreferencesConstants.BY_ARTIST -> if (ascending) sortedBy { it.artist } else sortedByDescending { it.artist }
-            CommonPreferencesConstants.BY_ALBUM -> if (ascending) sortedBy { it.album } else sortedByDescending { it.album }
-            CommonPreferencesConstants.BY_PATH -> if (ascending) sortedBy { it.uri } else sortedByDescending { it.uri }
+            CommonPreferencesConstants.BY_TITLE -> if (ascending) sortedBy { it.title?.lowercase() } else sortedByDescending { it.title?.lowercase() }
+            CommonPreferencesConstants.BY_ARTIST -> if (ascending) sortedBy { it.artist?.lowercase() } else sortedByDescending { it.artist?.lowercase() }
+            CommonPreferencesConstants.BY_ALBUM -> if (ascending) sortedBy { it.album?.lowercase() } else sortedByDescending { it.album?.lowercase() }
+            CommonPreferencesConstants.BY_PATH -> if (ascending) sortedBy { it.uri?.lowercase() } else sortedByDescending { it.uri?.lowercase() }
             CommonPreferencesConstants.BY_DATE_ADDED -> if (ascending) sortedBy { it.dateAdded } else sortedByDescending { it.dateAdded }
             CommonPreferencesConstants.BY_DATE_MODIFIED -> if (ascending) sortedBy { it.dateModified } else sortedByDescending { it.dateModified }
             CommonPreferencesConstants.BY_DURATION -> if (ascending) sortedBy { it.duration } else sortedByDescending { it.duration }
@@ -79,7 +79,7 @@ object PageSort {
                 }
                 if (ascending) sortedBy(trackInt) else sortedByDescending(trackInt)
             }
-            CommonPreferencesConstants.BY_COMPOSER -> if (ascending) sortedBy { it.composer } else sortedByDescending { it.composer }
+            CommonPreferencesConstants.BY_COMPOSER -> if (ascending) sortedBy { it.composer?.lowercase() } else sortedByDescending { it.composer?.lowercase() }
             else -> this
         }
     }

--- a/repository/src/main/java/app/simple/felicity/repository/sort/PlaylistSort.kt
+++ b/repository/src/main/java/app/simple/felicity/repository/sort/PlaylistSort.kt
@@ -26,23 +26,23 @@ object PlaylistSort {
     fun List<Audio>.sortedPlaylist(): List<Audio> {
         return when (PlaylistPreferences.getSongSort()) {
             CommonPreferencesConstants.BY_TITLE -> when (PlaylistPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.title }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.title }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.title?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.title?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_ARTIST -> when (PlaylistPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.artist }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.artist }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.artist?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.artist?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_ALBUM -> when (PlaylistPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.album }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.album }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.album?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.album?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_PATH -> when (PlaylistPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.uri }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.uri }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.uri?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.uri?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_DATE_ADDED -> when (PlaylistPreferences.getSortingStyle()) {
@@ -71,8 +71,8 @@ object PlaylistSort {
                 else -> this
             }
             CommonPreferencesConstants.BY_COMPOSER -> when (PlaylistPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.composer }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.composer }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.composer?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.composer?.lowercase() }
                 else -> this
             }
             else -> this

--- a/repository/src/main/java/app/simple/felicity/repository/sort/SearchSort.kt
+++ b/repository/src/main/java/app/simple/felicity/repository/sort/SearchSort.kt
@@ -11,23 +11,23 @@ object SearchSort {
     fun List<Audio>.searchSorted(): List<Audio> {
         return when (SearchPreferences.getSongSort()) {
             CommonPreferencesConstants.BY_TITLE -> when (SearchPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.title }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.title }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.title?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.title?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_ARTIST -> when (SearchPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.artist }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.artist }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.artist?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.artist?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_ALBUM -> when (SearchPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.album }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.album }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.album?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.album?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_PATH -> when (SearchPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.uri }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.uri }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.uri?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.uri?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_DATE_ADDED -> when (SearchPreferences.getSortingStyle()) {
@@ -56,8 +56,8 @@ object SearchSort {
                 else -> this
             }
             CommonPreferencesConstants.BY_COMPOSER -> when (SearchPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.composer }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.composer }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.composer?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.composer?.lowercase() }
                 else -> this
             }
             else -> this

--- a/repository/src/main/java/app/simple/felicity/repository/sort/SongSort.kt
+++ b/repository/src/main/java/app/simple/felicity/repository/sort/SongSort.kt
@@ -11,23 +11,23 @@ object SongSort {
     fun List<Audio>.sorted(): List<Audio> {
         return when (SongsPreferences.getSongSort()) {
             CommonPreferencesConstants.BY_TITLE -> when (SongsPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.title }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.title }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.title?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.title?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_ARTIST -> when (SongsPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.artist }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.artist }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.artist?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.artist?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_ALBUM -> when (SongsPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.album }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.album }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.album?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.album?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_PATH -> when (SongsPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.uri }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.uri }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.uri?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.uri?.lowercase() }
                 else -> this
             }
             CommonPreferencesConstants.BY_DATE_ADDED -> when (SongsPreferences.getSortingStyle()) {
@@ -56,8 +56,8 @@ object SongSort {
                 else -> this
             }
             CommonPreferencesConstants.BY_COMPOSER -> when (SongsPreferences.getSortingStyle()) {
-                CommonPreferencesConstants.ASCENDING -> sortedBy { it.composer }
-                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.composer }
+                CommonPreferencesConstants.ASCENDING -> sortedBy { it.composer?.lowercase() }
+                CommonPreferencesConstants.DESCENDING -> sortedByDescending { it.composer?.lowercase() }
                 else -> this
             }
             else -> this


### PR DESCRIPTION
String-keyed sorts (title, artist, album, name, composer, path) used Kotlin's natural String ordering, which compares by UTF-16 code unit. As a result uppercase letters (A-Z) sorted before all lowercase ones (a-z), so lowercase-named tracks, albums, and artists were pushed to the end of the list instead of their correct alphabetical position.

Apply .lowercase() to the string sort keys so ordering is case-insensitive, matching the existing convention already used in FolderSort, FolderHierarchySort, and GenreSort. This also makes the list panels' go-to-letter fast-scroller land correctly, since it groups sections by the case-folded first letter.