### PR TITLE
Fix(ui): fix artist pages reusing the first opened artist's artwork

### DIFF
--- a/music/src/main/java/app/simple/felicity/adapters/ui/page/PageAdapter.kt
+++ b/music/src/main/java/app/simple/felicity/adapters/ui/page/PageAdapter.kt
@@ -652,11 +652,7 @@ class PageAdapter(
                     }
                     is PageType.ArtistPage -> {
                         artFlow.visibility = View.VISIBLE
-                        val artist = Artist(
-                                id = 0,
-                                name = item.album.name,
-                                albumCount = 0,
-                                trackCount = 0,
+                        val artist = pageType.artist.copy(
                                 songPaths = pageData.songs.map { it.uri }
                         )
                         artFlow.setAdapter(SliderAdapter(ArtFlowData(R.string.artists, listOf(artist))))

--- a/music/src/main/java/app/simple/felicity/glide/artistcover/ArtistCoverLoader.kt
+++ b/music/src/main/java/app/simple/felicity/glide/artistcover/ArtistCoverLoader.kt
@@ -14,12 +14,11 @@ import java.io.File
 class ArtistCoverLoader(private val context: Context) : ModelLoader<Artist, Bitmap> {
     override fun buildLoadData(model: Artist, width: Int, height: Int, options: Options): ModelLoader.LoadData<Bitmap> {
         /**
-         * We mix the artist id with the saved image file's last-modified time so that
-         * whenever the user picks a new image (which overwrites the file on disk), the
-         * cache key changes and Glide fetches the fresh image instead of the old cached one.
+         * The saved image timestap invalidates manually picked or downloaded artwork,
+         * while song paths invalidate local fallback artwork when the library changes.
          */
         val lastModified = artistImageFile(model.name)?.lastModified() ?: 0L
-        val key = ObjectKey("${model.id}_$lastModified")
+        val key = createCacheKey(model, lastModified)
         return ModelLoader.LoadData(key, ArtistCoverFetcher(context, model))
     }
 
@@ -50,5 +49,23 @@ class ArtistCoverLoader(private val context: Context) : ModelLoader<Artist, Bitm
         }
 
         override fun teardown() {}
+    }
+
+    private data class ArtistCoverCacheKey(
+            val artistId: Long,
+            val artistName: String?,
+            val lastModified: Long,
+            val songPaths: List<String>
+    )
+
+    internal companion object {
+        fun createCacheKey(model: Artist, lastModified: Long): ObjectKey {
+            return ObjectKey(ArtistCoverCacheKey(
+                    artistId = model.id,
+                    artistName = model.name,
+                    lastModified = lastModified,
+                    songPaths = model.songPaths.toList()
+            ))
+        }
     }
 }

--- a/music/src/test/java/app/simple/felicity/glide/artistcover/ArtistCoverLoaderTest.kt
+++ b/music/src/test/java/app/simple/felicity/glide/artistcover/ArtistCoverLoaderTest.kt
@@ -1,0 +1,51 @@
+package app.simple.felicity.glide.artistcover
+
+import app.simple.felicity.repository.models.Artist
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ArtistCoverLoaderTest {
+
+    @Test
+    fun cacheKeyDiffersForDifferentArtistsWithoutSavedImages() {
+        val firstArtist = artist(id = 1L, name = "Artist X", songPaths = listOf("content://song/1"))
+        val secondArtist = artist(id = 2L, name = "Artist Y", songPaths = listOf("content://song/2"))
+
+        assertNotEquals(
+                ArtistCoverLoader.createCacheKey(firstArtist, lastModified = 0L),
+                ArtistCoverLoader.createCacheKey(secondArtist, lastModified = 0L)
+        )
+    }
+
+    @Test
+    fun cacheKeyChangesWhenArtistSongPathsChange() {
+        val original = artist(id = 1L, name = "Artist X", songPaths = listOf("content://song/1"))
+        val updated = original.copy(songPaths = listOf("content://song/2"))
+
+        assertNotEquals(
+                ArtistCoverLoader.createCacheKey(original, lastModified = 0L),
+                ArtistCoverLoader.createCacheKey(updated, lastModified = 0L)
+        )
+    }
+
+    @Test
+    fun cacheKeyIsStableForUnchangedArtworkSources() {
+        val artist = artist(id = 1L, name = "Artist X", songPaths = listOf("content://song/1"))
+
+        assertEquals(
+                ArtistCoverLoader.createCacheKey(artist, lastModified = 123L),
+                ArtistCoverLoader.createCacheKey(artist, lastModified = 123L)
+        )
+    }
+
+    private fun artist(id: Long, name: String, songPaths: List<String>): Artist {
+        return Artist(
+                id = id,
+                name = name,
+                albumCount = 1,
+                trackCount = songPaths.size,
+                songPaths = songPaths
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Fixes artist pages reusing the first opened artist's artwork.

- Preserves the real artist ID when loading header artwork.
- Includes artwork source paths in Glide's cache key to prevent collisions and stale covers after library updates.
- Adds regression tests for cache-key behavior.